### PR TITLE
 #72 fix : brand 파라미터 존재하지 않을 시 null 처리하여 Optional로 작동하도록

### DIFF
--- a/src/main/java/com/idea5/four_cut_photos_map/domain/shop/service/ShopService.java
+++ b/src/main/java/com/idea5/four_cut_photos_map/domain/shop/service/ShopService.java
@@ -57,7 +57,7 @@ public class ShopService {
     }
 
     @Transactional(readOnly = true)
-    private List<Shop> compareRoadAddressName(KakaoMapSearchDto apiShop) {
+    public List<Shop> compareRoadAddressName(KakaoMapSearchDto apiShop) {
         List<Shop> dbShops = shopRepository.findDistinctByRoadAddressName(apiShop.getRoadAddressName());
         return dbShops;
     }
@@ -79,6 +79,7 @@ public class ShopService {
     }
 
     public List<KakaoMapSearchDto> searchKakaoMapByBrand(RequestBrandSearch brandSearch) {
+        if(brandSearch.getBrand()==null) brandSearch.setBrand("");
         return kakaoMapSearchApi.searchByQueryWord (
                 brandSearch.getBrand(),
                 brandSearch.getLongitude(),


### PR DESCRIPTION
### 목적
> brand 파라미터 존재하지 않을 시 null 처리하여 Optional로 작동하도록
### 작업 상세
- 수정 이전
  -   `/shops/brand?longitude=${longitude}&latitude=${latitude}&brand=`
  - 전체 브랜드 조회 시에도 위와 같이 brand 파라미터가 아예 누락되지 않고 빈문자열로 존재해야 의도대로 전체 브랜드가 조회되었음
- 수정 이후
   - `/shops/brand?longitude=${longitude}&latitude=${latitude}` 
   - brand 파라미터가 Optional 될 수 있도록 처리
   -  아예 존재하지 않을 시(null) RequestBrandSearch의 brand 필드를 빈문자열("")로 초기화하여 카카오맵 조회 API 요청