### PR TITLE
#90 refactor : 상세조회 찜목록조회 시 호출하는 카카오맵 API 조회 정확도 개선

### DIFF
--- a/src/main/java/com/idea5/four_cut_photos_map/domain/shop/service/ShopService.java
+++ b/src/main/java/com/idea5/four_cut_photos_map/domain/shop/service/ShopService.java
@@ -70,7 +70,7 @@ public class ShopService {
     }
 
     public ResponseShopDetail renameShopAndSetResponseDto(Shop dbShop, String distance) {
-        String[] apiShop = kakaoMapSearchApi.searchByRoadAddressName(dbShop.getRoadAddressName());
+        String[] apiShop = kakaoMapSearchApi.searchByRoadAddressName(dbShop.getRoadAddressName(), dbShop.getPlaceName());
 
         if(apiShop == null) throw new BusinessException(INVALID_SHOP_ID);
         String placeName = apiShop[0];
@@ -84,6 +84,7 @@ public class ShopService {
     public FavoriteResponse renameShopAndSetResponseDto(Favorite favorite, Double curLnt, Double curLat) {
         String[] apiShop = kakaoMapSearchApi.searchByRoadAddressName(
                 favorite.getShop().getRoadAddressName(),
+                favorite.getShop().getPlaceName(),
                 curLnt,
                 curLat
         );

--- a/src/main/java/com/idea5/four_cut_photos_map/domain/shop/service/kakao/KakaoMapSearchApi.java
+++ b/src/main/java/com/idea5/four_cut_photos_map/domain/shop/service/kakao/KakaoMapSearchApi.java
@@ -64,14 +64,18 @@ public class KakaoMapSearchApi {
         return deserialize(resultList, documents);
     }
 
-    public String[] searchByRoadAddressName(String roadAddressName) {
-        // 1. Redis에서 조회
+    public String[] searchByRoadAddressName(String roadAddressName, String placeName) {
+        // 1-1. Redis에서 조회
         String cacheKey = redisDao.getRoadAddressKey(roadAddressName);
         String cachedData = redisDao.getValues(cacheKey);
 
         if (cachedData != null) {
-            log.info("=====RoadAddressName Cache Hit=====");
-            return cachedData.split(",");
+            String[] cached = cachedData.split((","));
+            // 1-2. apiShop의 brand명이 dbShop의 placeName에 포함되는지 확인
+            if(placeName.contains(cached[0].split(" ")[0])) {
+                log.info("=====RoadAddressName Cache Hit=====");
+                return cachedData.split(",");
+            }
         }
         log.info("=====RoadAddressName Cache Miss=====");
 
@@ -94,7 +98,7 @@ public class KakaoMapSearchApi {
         // 도로명주소와 DEFAULT_QUERY_WORD로 검색 시
         // 100% 일치하는 데이터가 항상 상단에 노출되지 않음
         // 따라서, 여러 데이터 중 요청 도로명 주소와 일치하는 데이터 1개만 찾아서 반환
-        String[] result = matchAndDeserialize(documents, roadAddressName);
+        String[] result = matchAndDeserialize(documents, roadAddressName, placeName);
         if(result != null){
             // 5. Redis에 데이터 저장
             redisDao.setValues(cacheKey, String.join(",", result), Duration.ofDays(1));
@@ -104,7 +108,7 @@ public class KakaoMapSearchApi {
         }
     }
 
-    public String[] searchByRoadAddressName(String roadAddressName, Double curLnt, Double curLat) {
+    public String[] searchByRoadAddressName(String roadAddressName, String placeName, Double curLnt, Double curLat) {
         // 1. API 호출을 위한 요청 설정
         String apiPath = "/v2/local/search/keyword.json";
         String apiUrl = UriComponentsBuilder.fromPath(apiPath)
@@ -126,7 +130,7 @@ public class KakaoMapSearchApi {
         // 도로명주소와 DEFAULT_QUERY_WORD로 검색 시
         // 100% 일치하는 데이터가 항상 상단에 노출되지 않음
         // 따라서, 여러 데이터 중 요청 도로명 주소와 일치하는 데이터 1개만 찾아서 반환
-        String[] result = matchAndDeserializeWithCurLocation(documents, roadAddressName);
+        String[] result = matchAndDeserializeWithCurLocation(documents, roadAddressName, placeName);
         return result;
     }
 
@@ -146,26 +150,30 @@ public class KakaoMapSearchApi {
         return resultList;
     }
 
-    private String[] matchAndDeserialize(JsonNode documents, String roadAddressName) {
+    private String[] matchAndDeserialize(JsonNode documents, String roadAddressName, String placeName) {
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         for (JsonNode document : documents) {
             if (document.get("road_address_name").asText().equals(roadAddressName)) {
-                return new String[]{
-                        document.get("place_name").asText(), document.get("place_url").asText(),
-                        document.get("x").asText(), document.get("y").asText()
-                };
+                if(placeName.contains(document.get("place_name").asText().split(" ")[0])) {
+                    return new String[]{
+                            document.get("place_name").asText(), document.get("place_url").asText(),
+                            document.get("x").asText(), document.get("y").asText()
+                    };
+                }
             }
         }
         return null;
     }
 
-    private String[] matchAndDeserializeWithCurLocation(JsonNode documents, String roadAddressName) {
+    private String[] matchAndDeserializeWithCurLocation(JsonNode documents, String roadAddressName, String placeName) {
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         for (JsonNode document : documents) {
             if (document.get("road_address_name").asText().equals(roadAddressName)) {
-                return new String[]{
-                        document.get("place_name").asText(), Util.distanceFormatting(document.get("distance").asText())
-                };
+                if(placeName.contains(document.get("place_name").asText().split(" ")[0])) {
+                    return new String[]{
+                            document.get("place_name").asText(), Util.distanceFormatting(document.get("distance").asText())
+                    };
+                }
             }
         }
         return null;

--- a/src/main/java/com/idea5/four_cut_photos_map/global/error/ErrorCode.java
+++ b/src/main/java/com/idea5/four_cut_photos_map/global/error/ErrorCode.java
@@ -13,8 +13,7 @@ import static com.idea5.four_cut_photos_map.domain.favorite.service.FavoriteServ
 public enum ErrorCode {
     TEST(HttpStatus.INTERNAL_SERVER_ERROR, "001", "business Error"),
     SHOP_NOT_FOUND(HttpStatus.NOT_FOUND, "404", "조회한 지점이 존재하지 않습니다."),
-    DISTANCE_IS_EMPTY(HttpStatus.BAD_REQUEST, "400", "[distance] 거리가 빈 공백이거나 누락되었습니다."),
-    INVALID_SHOP_ID(HttpStatus.BAD_REQUEST, "400", "[id] 해당 id는 셀프 즉석사진관에 해당하는 id가 아닙니다. DB에 저장된 데이터 중 다른 업종에 속한 id 입니다."),
+    INVALID_SHOP_ID(HttpStatus.BAD_REQUEST, "400", "[id] 도로명주소나 브랜드명 불일치로 카카오맵에서 일치하는 데이터가 없는 id 입니다. 다른 id로 요청해주세요."),
 
     // 인증 관련 오류
     NON_TOKEN(HttpStatus.UNAUTHORIZED, "100", "HTTP Authorization header 에 토큰을 담아 요청해주세요."),


### PR DESCRIPTION
### 목적
> 상세조회 찜목록조회 시 호출하는 카카오맵 API 조회 정확도 개선
### 작업 상세
- 도로명주소로 카카오맵 API 조회 시 결과값의 브랜드명이 DB의 '장소명'에 포함되어있고 DB의 '도로명주소'와 일치하는지 확인
### 관련 Issue
- https://github.com/4-frame-photos-map/backend/issues/90