### PR TITLE
fix : 홈 탭과 내 주변 탭에서 지도 중심좌표 도로명주소 존재하지 않을 시 지번으로 노출

### DIFF
--- a/src/main/java/com/idea5/four_cut_photos_map/domain/shop/service/kakao/KakaoMapSearchApi.java
+++ b/src/main/java/com/idea5/four_cut_photos_map/domain/shop/service/kakao/KakaoMapSearchApi.java
@@ -174,13 +174,12 @@ public class KakaoMapSearchApi {
         } catch (Exception e) {
             throw new BusinessException(TOO_MANY_REQUESTS);
         }
-        log.info(documents.size()+"이거="+documents);
 
         // 3. JSON -> DTO 역직렬화
         String roadAddressName = Optional.ofNullable(documents.get(0).get("road_address"))
                 .map(jsonNode -> jsonNode.get("address_name"))
                 .map(JsonNode::asText)
-                .orElse("");
+                .orElse(documents.get(0).get("address").get("address_name").asText());
 
         return roadAddressName;
     }


### PR DESCRIPTION
### 관련 이슈
- https://github.com/4-frame-photos-map/backend/issues/108