### PR TITLE
#84 refactor: 리뷰 서비스의 읽기, 쓰기 로직 분리

### DIFF
--- a/src/main/java/com/idea5/four_cut_photos_map/domain/member/service/MemberService.java
+++ b/src/main/java/com/idea5/four_cut_photos_map/domain/member/service/MemberService.java
@@ -1,8 +1,8 @@
 package com.idea5.four_cut_photos_map.domain.member.service;
 
+import com.idea5.four_cut_photos_map.domain.auth.dto.param.KakaoUserInfoParam;
 import com.idea5.four_cut_photos_map.domain.auth.dto.param.LoginMemberParam;
 import com.idea5.four_cut_photos_map.domain.auth.dto.response.KakaoTokenResp;
-import com.idea5.four_cut_photos_map.domain.auth.dto.param.KakaoUserInfoParam;
 import com.idea5.four_cut_photos_map.domain.favorite.service.FavoriteService;
 import com.idea5.four_cut_photos_map.domain.member.dto.request.MemberUpdateReq;
 import com.idea5.four_cut_photos_map.domain.member.dto.response.MemberInfoResp;
@@ -13,7 +13,7 @@ import com.idea5.four_cut_photos_map.domain.member.entity.Member;
 import com.idea5.four_cut_photos_map.domain.member.repository.MemberRepository;
 import com.idea5.four_cut_photos_map.domain.memberTitle.entity.MemberTitleLog;
 import com.idea5.four_cut_photos_map.domain.memberTitle.service.MemberTitleService;
-import com.idea5.four_cut_photos_map.domain.review.service.ReviewService;
+import com.idea5.four_cut_photos_map.domain.review.service.ReviewWriteService;
 import com.idea5.four_cut_photos_map.global.common.RedisDao;
 import com.idea5.four_cut_photos_map.global.error.ErrorCode;
 import com.idea5.four_cut_photos_map.global.error.exception.BusinessException;
@@ -38,7 +38,7 @@ public class MemberService {
     private final MemberTitleService memberTitleService;
     private final FavoriteService favoriteService;
     private final JwtService jwtService;
-    private final ReviewService reviewService;
+    private final ReviewWriteService reviewWriteService;
 
     // 서비스 로그인
     @Transactional
@@ -132,7 +132,7 @@ public class MemberService {
         // 2. Member 삭제하기 전 Member 를 참조하고 있는 엔티티(MemberTitleLog, Favorite, Review) 먼저 삭제하기
         memberTitleService.deleteByMemberId(id);
         favoriteService.deleteByMemberId(id);
-        reviewService.deleteByWriterId(id);
+        reviewWriteService.deleteByWriterId(id);
         // 3. DB 에서 회원 삭제
         memberRepository.deleteById(id);
         return new MemberWithdrawlResp(id);

--- a/src/main/java/com/idea5/four_cut_photos_map/domain/review/entity/Review.java
+++ b/src/main/java/com/idea5/four_cut_photos_map/domain/review/entity/Review.java
@@ -1,6 +1,7 @@
 package com.idea5.four_cut_photos_map.domain.review.entity;
 
 import com.idea5.four_cut_photos_map.domain.member.entity.Member;
+import com.idea5.four_cut_photos_map.domain.review.dto.request.RequestReviewDto;
 import com.idea5.four_cut_photos_map.domain.review.entity.score.ItemScore;
 import com.idea5.four_cut_photos_map.domain.review.entity.score.PurityScore;
 import com.idea5.four_cut_photos_map.domain.review.entity.score.RetouchScore;
@@ -13,7 +14,6 @@ import javax.persistence.*;
 
 @Entity
 @Getter
-@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @SuperBuilder
@@ -42,4 +42,13 @@ public class Review extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ItemScore item;
 
+    public Review update(RequestReviewDto dto) {
+        this.starRating = dto.getStarRating();
+        this.content = dto.getContent();
+        this.purity = PurityScore.valueOf(dto.getPurity());
+        this.retouch = RetouchScore.valueOf(dto.getRetouch());
+        this.item = ItemScore.valueOf(dto.getItem());
+
+        return this;
+    }
 }

--- a/src/main/java/com/idea5/four_cut_photos_map/domain/review/mapper/ReviewMapper.java
+++ b/src/main/java/com/idea5/four_cut_photos_map/domain/review/mapper/ReviewMapper.java
@@ -17,21 +17,31 @@ import com.idea5.four_cut_photos_map.domain.review.entity.score.RetouchScore;
 import com.idea5.four_cut_photos_map.domain.shop.entity.Shop;
 
 public class ReviewMapper {
-    public static Review toEntity(Member writer, Shop shop, RequestReviewDto reviewDto) {
-        Review review = toEntity(reviewDto);
-        review.setWriter(writer);
-        review.setShop(shop);
+    private static RequestReviewDto setDefaultScore(RequestReviewDto dto) {
+        if(dto.getPurity() == null) dto.setPurity("UNSELECTED");
+        if(dto.getRetouch() == null) dto.setRetouch("UNSELECTED");
+        if(dto.getItem() == null) dto.setItem("UNSELECTED");
 
-        return review;
+        return dto;
     }
-    public static Review toEntity(RequestReviewDto reviewDto) {
+    public static Review toEntity(Member writer, Shop shop, RequestReviewDto dto) {
+        dto = setDefaultScore(dto);
+
         return Review.builder()
-                .starRating(reviewDto.getStarRating())
-                .content(reviewDto.getContent())
-                .purity(reviewDto.getPurity() == null ? PurityScore.UNSELECTED : PurityScore.valueOf(reviewDto.getPurity()))
-                .retouch(reviewDto.getRetouch() == null ? RetouchScore.UNSELECTED : RetouchScore.valueOf(reviewDto.getRetouch()))
-                .item(reviewDto.getItem() == null ? ItemScore.UNSELECTED : ItemScore.valueOf(reviewDto.getItem()))
+                .writer(writer)
+                .shop(shop)
+                .starRating(dto.getStarRating())
+                .content(dto.getContent())
+                .purity(PurityScore.valueOf(dto.getPurity()))
+                .retouch(RetouchScore.valueOf(dto.getRetouch()))
+                .item(ItemScore.valueOf(dto.getItem()))
                 .build();
+    }
+
+    public static Review update(Review review, RequestReviewDto dto) {
+        dto = setDefaultScore(dto);
+
+        return review.update(dto);
     }
 
     /**

--- a/src/main/java/com/idea5/four_cut_photos_map/domain/review/service/ReviewReadService.java
+++ b/src/main/java/com/idea5/four_cut_photos_map/domain/review/service/ReviewReadService.java
@@ -2,12 +2,8 @@ package com.idea5.four_cut_photos_map.domain.review.service;
 
 import com.idea5.four_cut_photos_map.domain.member.entity.Member;
 import com.idea5.four_cut_photos_map.domain.memberTitle.service.MemberTitleService;
-import com.idea5.four_cut_photos_map.domain.review.dto.request.RequestReviewDto;
 import com.idea5.four_cut_photos_map.domain.review.dto.response.*;
 import com.idea5.four_cut_photos_map.domain.review.entity.Review;
-import com.idea5.four_cut_photos_map.domain.review.entity.score.ItemScore;
-import com.idea5.four_cut_photos_map.domain.review.entity.score.PurityScore;
-import com.idea5.four_cut_photos_map.domain.review.entity.score.RetouchScore;
 import com.idea5.four_cut_photos_map.domain.review.mapper.ReviewMapper;
 import com.idea5.four_cut_photos_map.domain.review.repository.ReviewRepository;
 import com.idea5.four_cut_photos_map.domain.shop.entity.Shop;
@@ -24,22 +20,13 @@ import java.util.stream.Collectors;
 
 @Slf4j
 @Service
-@Transactional
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class ReviewService {
+public class ReviewReadService {
     private final MemberTitleService memberTitleService;
     private final ReviewRepository reviewRepository;
     private final ShopService shopService;
 
-    private boolean actorCanModify(Member member, Review review) {
-        return member.getId() == review.getWriter().getId();
-    }
-
-    private boolean actorCanDelete(Member member, Review review) {
-        return actorCanModify(member, review);
-    }
-
-    @Transactional(readOnly = true)
     public ResponseReviewDto getReviewById(Long reviewId) {
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.REVIEW_NOT_FOUND));
@@ -47,7 +34,6 @@ public class ReviewService {
         return ReviewMapper.toResponseReviewDto(review);
     }
 
-    @Transactional(readOnly = true)
     public List<ResponseShopReviewDto> getAllShopReviews(Long shopId) {
         Shop shop = shopService.findById(shopId);
 
@@ -58,7 +44,6 @@ public class ReviewService {
     }
 
     // 지점 전체 리뷰 조회
-    @Transactional(readOnly = true)
     public List<ShopReviewResp> getAllShopReview(Long shopId) {
         Shop shop = shopService.findById(shopId);
 
@@ -71,7 +56,6 @@ public class ReviewService {
                 .collect(Collectors.toList());
     }
 
-    @Transactional(readOnly = true)
     public List<ResponseMemberReviewDto> getAllMemberReviews(Long memberId) {
         List<Review> reviews = reviewRepository.findAllByWriterIdOrderByCreateDateDesc(memberId);
 
@@ -80,8 +64,6 @@ public class ReviewService {
                 .collect(Collectors.toList());
     }
 
-
-    @Transactional(readOnly = true)
     public List<ResponseShopReviewDto> getTop3ShopReviews(Long shopId) {
         List<Review> reviews = reviewRepository.findTop3ByShopIdOrderByCreateDateDesc(shopId);
 
@@ -91,7 +73,6 @@ public class ReviewService {
     }
 
     // 리뷰 최신순 3개 조회
-    @Transactional(readOnly = true)
     public List<ShopReviewResp> getTop3ShopReview(Long shopId) {
         List<Review> reviews = reviewRepository.findTop3ByShopIdOrderByCreateDateDesc(shopId);
 
@@ -103,52 +84,11 @@ public class ReviewService {
                 .collect(Collectors.toList());
     }
 
-    public ResponseReviewDto write(Member member, Long shopId, RequestReviewDto reviewDto) {
-        Shop shop = shopService.findById(shopId);
-
-        Review savedReview = reviewRepository.save(ReviewMapper.toEntity(member, shop, reviewDto));
-
-        return ReviewMapper.toResponseReviewDto(savedReview);
-    }
-
-    public ResponseReviewDto modify(Member member, Long reviewId, RequestReviewDto reviewDto) {
-        Review review = reviewRepository.findById(reviewId).orElseThrow(() -> new BusinessException(ErrorCode.REVIEW_NOT_FOUND));
-
-        // 수정 권한 확인
-        if(!actorCanModify(member, review)) {
-            throw new BusinessException(ErrorCode.WRITER_DOES_NOT_MATCH);
-        }
-
-        ReviewMapper.update(review, reviewDto);
-
-        return ReviewMapper.toResponseReviewDto(review);
-    }
-
-    public Long delete(Member member, Long reviewId) {
-        Review review = reviewRepository.findById(reviewId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.REVIEW_NOT_FOUND));
-        
-        if(!actorCanDelete(member, review)) {
-            throw new BusinessException(ErrorCode.WRITER_DOES_NOT_MATCH);
-        }
-
-        Long shopId = review.getShop().getId();
-
-        reviewRepository.delete(review);
-
-        return shopId;
-    }
-
     // 회원의 리뷰수 조회
     public Long getReviewCntByWriter(Member member) {
         return reviewRepository.countByWriter(member);
     }
 
-    public void deleteByWriterId(Long memberId) {
-        reviewRepository.deleteByWriterId(memberId);
-    }
-
-    @Transactional(readOnly = true)
     public ShopReviewInfoDto getShopReviewInfo(Long shopId) {
         Shop shop = shopService.findById(shopId);
 

--- a/src/main/java/com/idea5/four_cut_photos_map/domain/review/service/ReviewService.java
+++ b/src/main/java/com/idea5/four_cut_photos_map/domain/review/service/ReviewService.java
@@ -119,19 +119,9 @@ public class ReviewService {
             throw new BusinessException(ErrorCode.WRITER_DOES_NOT_MATCH);
         }
 
-        review = updateReview(review, reviewDto);
+        ReviewMapper.update(review, reviewDto);
 
         return ReviewMapper.toResponseReviewDto(review);
-    }
-
-    private Review updateReview(Review review, RequestReviewDto dto) {
-        review.setStarRating(dto.getStarRating());
-        review.setContent(dto.getContent());
-        review.setPurity(dto.getPurity() == null ? PurityScore.UNSELECTED : PurityScore.valueOf(dto.getPurity()));
-        review.setRetouch(dto.getRetouch() == null ? RetouchScore.UNSELECTED : RetouchScore.valueOf(dto.getRetouch()));
-        review.setItem(dto.getItem() == null ? ItemScore.UNSELECTED : ItemScore.valueOf(dto.getItem()));
-
-        return review;
     }
 
     public Long delete(Member member, Long reviewId) {

--- a/src/main/java/com/idea5/four_cut_photos_map/domain/review/service/ReviewWriteService.java
+++ b/src/main/java/com/idea5/four_cut_photos_map/domain/review/service/ReviewWriteService.java
@@ -1,0 +1,61 @@
+package com.idea5.four_cut_photos_map.domain.review.service;
+
+import com.idea5.four_cut_photos_map.domain.member.entity.Member;
+import com.idea5.four_cut_photos_map.domain.review.dto.request.RequestReviewDto;
+import com.idea5.four_cut_photos_map.domain.review.dto.response.ResponseReviewDto;
+import com.idea5.four_cut_photos_map.domain.review.entity.Review;
+import com.idea5.four_cut_photos_map.domain.review.mapper.ReviewMapper;
+import com.idea5.four_cut_photos_map.domain.review.repository.ReviewRepository;
+import com.idea5.four_cut_photos_map.domain.shop.entity.Shop;
+import com.idea5.four_cut_photos_map.domain.shop.service.ShopService;
+import com.idea5.four_cut_photos_map.global.error.ErrorCode;
+import com.idea5.four_cut_photos_map.global.error.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ReviewWriteService {
+    private final ReviewRepository reviewRepository;
+    private final ShopService shopService;
+
+    private void authorizeReviewWriter(Member member, Review review) {
+        if(!(member.getId() == review.getWriter().getId()))
+            throw new BusinessException(ErrorCode.WRITER_DOES_NOT_MATCH);
+    }
+
+    public ResponseReviewDto write(Member member, Long shopId, RequestReviewDto reviewDto) {
+        Shop shop = shopService.findById(shopId);
+
+        Review savedReview = reviewRepository.save(ReviewMapper.toEntity(member, shop, reviewDto));
+
+        return ReviewMapper.toResponseReviewDto(savedReview);
+    }
+
+    public ResponseReviewDto modify(Member member, Long reviewId, RequestReviewDto reviewDto) {
+        Review review = reviewRepository.findById(reviewId).orElseThrow(() -> new BusinessException(ErrorCode.REVIEW_NOT_FOUND));
+
+        authorizeReviewWriter(member, review);
+
+        ReviewMapper.update(review, reviewDto);
+
+        return ReviewMapper.toResponseReviewDto(review);
+    }
+
+    public Long delete(Member member, Long reviewId) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.REVIEW_NOT_FOUND));
+        Long shopId = review.getShop().getId();
+
+        authorizeReviewWriter(member, review);
+
+        reviewRepository.delete(review);
+        return shopId;
+    }
+
+    public void deleteByWriterId(Long memberId) {
+        reviewRepository.deleteByWriterId(memberId);
+    }
+}

--- a/src/main/java/com/idea5/four_cut_photos_map/domain/shop/controller/ShopController.java
+++ b/src/main/java/com/idea5/four_cut_photos_map/domain/shop/controller/ShopController.java
@@ -4,7 +4,7 @@ package com.idea5.four_cut_photos_map.domain.shop.controller;
 import com.idea5.four_cut_photos_map.domain.favorite.entity.Favorite;
 import com.idea5.four_cut_photos_map.domain.favorite.service.FavoriteService;
 import com.idea5.four_cut_photos_map.domain.review.dto.response.ShopReviewResp;
-import com.idea5.four_cut_photos_map.domain.review.service.ReviewService;
+import com.idea5.four_cut_photos_map.domain.review.service.ReviewReadService;
 import com.idea5.four_cut_photos_map.domain.shop.dto.response.KakaoMapSearchDto;
 import com.idea5.four_cut_photos_map.domain.shop.dto.response.ResponseShopBrand;
 import com.idea5.four_cut_photos_map.domain.shop.dto.response.ResponseShopDetail;
@@ -36,7 +36,7 @@ import java.util.Map;
 public class ShopController {
     private final ShopService shopService;
     private final FavoriteService favoriteService;
-    private final ReviewService reviewService;
+    private final ReviewReadService reviewReadService;
     private final ShopTitleLogService shopTitleLogService;
 
 
@@ -134,7 +134,7 @@ public class ShopController {
         Shop dbShop = shopService.findById(id);
         ResponseShopDetail shopDetailDto = shopService.setResponseDto(dbShop, userLat, userLng);
 
-        List<ShopReviewResp> recentReviews = reviewService.getTop3ShopReview(shopDetailDto.getId());
+        List<ShopReviewResp> recentReviews = reviewReadService.getTop3ShopReview(shopDetailDto.getId());
         shopDetailDto.setRecentReviews(recentReviews);
 
         if (memberContext != null) {

--- a/src/main/java/com/idea5/four_cut_photos_map/job/CollectService.java
+++ b/src/main/java/com/idea5/four_cut_photos_map/job/CollectService.java
@@ -6,7 +6,7 @@ import com.idea5.four_cut_photos_map.domain.memberTitle.entity.MemberTitle;
 import com.idea5.four_cut_photos_map.domain.memberTitle.entity.MemberTitleLog;
 import com.idea5.four_cut_photos_map.domain.memberTitle.entity.MemberTitleType;
 import com.idea5.four_cut_photos_map.domain.memberTitle.repository.MemberTitleLogRepository;
-import com.idea5.four_cut_photos_map.domain.review.service.ReviewService;
+import com.idea5.four_cut_photos_map.domain.review.service.ReviewReadService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class CollectService {
     private final MemberTitleLogRepository memberTitleLogRepository;
     private final FavoriteService favoriteService;
-    private final ReviewService reviewService;
+    private final ReviewReadService reviewReadService;
 
     // 대표 칭호 부여
     @Transactional
@@ -39,12 +39,12 @@ public class CollectService {
             // 1. 회원가입
             return true;
         } else if(memberTitle.getId() == MemberTitleType.FIRST_REVIEW.getCode()) {
-            if(reviewService.getReviewCntByWriter(member) >= 1) {
+            if(reviewReadService.getReviewCntByWriter(member) >= 1) {
                 // 2. 첫번째 리뷰
                 return true;
             }
         } else if(memberTitle.getId() == MemberTitleType.MANY_REVIEW.getCode()) {
-            if(reviewService.getReviewCntByWriter(member) >= 3) {
+            if(reviewReadService.getReviewCntByWriter(member) >= 3) {
                 // 3. 리뷰 5개 이상
                 return true;
             }

--- a/src/test/java/com/idea5/four_cut_photos_map/domain/review/unit/service/ReviewReadServiceTest.java
+++ b/src/test/java/com/idea5/four_cut_photos_map/domain/review/unit/service/ReviewReadServiceTest.java
@@ -1,9 +1,7 @@
 package com.idea5.four_cut_photos_map.domain.review.unit.service;
 
 import com.idea5.four_cut_photos_map.domain.brand.entity.Brand;
-import com.idea5.four_cut_photos_map.domain.brand.entity.MajorBrand;
 import com.idea5.four_cut_photos_map.domain.member.entity.Member;
-import com.idea5.four_cut_photos_map.domain.review.dto.request.RequestReviewDto;
 import com.idea5.four_cut_photos_map.domain.review.dto.response.ResponseMemberReviewDto;
 import com.idea5.four_cut_photos_map.domain.review.dto.response.ResponseReviewDto;
 import com.idea5.four_cut_photos_map.domain.review.dto.response.ResponseShopReviewDto;
@@ -14,9 +12,8 @@ import com.idea5.four_cut_photos_map.domain.review.entity.score.PurityScore;
 import com.idea5.four_cut_photos_map.domain.review.entity.score.RetouchScore;
 import com.idea5.four_cut_photos_map.domain.review.mapper.ReviewMapper;
 import com.idea5.four_cut_photos_map.domain.review.repository.ReviewRepository;
-import com.idea5.four_cut_photos_map.domain.review.service.ReviewService;
+import com.idea5.four_cut_photos_map.domain.review.service.ReviewReadService;
 import com.idea5.four_cut_photos_map.domain.shop.entity.Shop;
-import com.idea5.four_cut_photos_map.domain.shop.repository.ShopRepository;
 import com.idea5.four_cut_photos_map.domain.shop.service.ShopService;
 import com.idea5.four_cut_photos_map.global.error.ErrorCode;
 import com.idea5.four_cut_photos_map.global.error.exception.BusinessException;
@@ -24,9 +21,7 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.stubbing.OngoingStubbing;
 
 import java.time.LocalDateTime;
 import java.util.*;
@@ -36,9 +31,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class ReviewServiceTest {
+public class ReviewReadServiceTest {
     @InjectMocks
-    private ReviewService reviewService;
+    private ReviewReadService reviewReadService;
     @Mock
     private ReviewRepository reviewRepository;
     @Mock
@@ -72,7 +67,7 @@ public class ReviewServiceTest {
                 // when
                 when(reviewRepository.findById(retrieveReviewId)).thenReturn(Optional.of(review));
 
-                ResponseReviewDto responseReviewDto = reviewService.getReviewById(retrieveReviewId);
+                ResponseReviewDto responseReviewDto = reviewReadService.getReviewById(retrieveReviewId);
 
                 // then
                 Assertions.assertEquals(responseReviewDto.getReviewInfo().getId(), review.getId());
@@ -102,178 +97,7 @@ public class ReviewServiceTest {
                 when(reviewRepository.findById(retrieveReviewId)).thenThrow(exception);
 
                 // then
-                BusinessException resultException = Assertions.assertThrows(exception.getClass(), () -> reviewService.getReviewById(retrieveReviewId));
-                Assertions.assertEquals(resultException.getMessage(), exception.getMessage());
-            }
-        }
-    }
-
-    @Nested
-    @DisplayName("특정 리뷰 수정")
-    class ModifyReview {
-        private Member writer;
-        private Brand brand;
-        private Shop shop;
-        private Review review;
-
-        @BeforeEach
-        void setUp() {
-            writer = Member.builder().id(1L).kakaoId(1000L).nickname("user1").build();
-            brand = Brand.builder().id(1L).brandName("인생네컷").filePath("https://d18tllc1sxg8cp.cloudfront.net/brand_image/brand_1.jpg").build();
-            shop = Shop.builder().id(1L).brand(brand).placeName("인생네컷망리단길점").address("서울 마포구 포은로 109-1").favoriteCnt(0).reviewCnt(0).starRatingAvg(0.0).build();
-            review = Review.builder().id(1L).createDate(LocalDateTime.now()).modifyDate(LocalDateTime.now()).writer(writer).shop(shop).starRating(5).content("리뷰 내용").purity(PurityScore.BAD).retouch(RetouchScore.BAD).item(ItemScore.BAD).build();
-        }
-
-        @Nested
-        @DisplayName("성공")
-        class SuccessCase {
-            @Test
-            @DisplayName("해당 id 가진 리뷰 수정")
-            void modifyReviewSuccess1() {
-                // given
-                Long modifyReviewId = 1L;
-                Member user = Member.builder().id(1L).build();
-                RequestReviewDto modifyReviewDto = RequestReviewDto.builder().starRating(3).content("수정 후 리뷰 내용").purity("GOOD").retouch("GOOD").item("GOOD").build();
-
-                // when
-                when(reviewRepository.findById(modifyReviewId)).thenReturn(Optional.of(review));
-
-                ResponseReviewDto responseReviewDto = reviewService.modify(user, modifyReviewId, modifyReviewDto);
-
-                // then
-                Assertions.assertEquals(responseReviewDto.getReviewInfo().getStarRating(), modifyReviewDto.getStarRating());
-                Assertions.assertEquals(responseReviewDto.getReviewInfo().getContent(), modifyReviewDto.getContent());
-                Assertions.assertEquals(responseReviewDto.getReviewInfo().getPurity(), PurityScore.valueOf(modifyReviewDto.getPurity()));
-                Assertions.assertEquals(String.valueOf(responseReviewDto.getReviewInfo().getRetouch()), modifyReviewDto.getRetouch());
-                Assertions.assertEquals(String.valueOf(responseReviewDto.getReviewInfo().getItem()), modifyReviewDto.getItem());
-            }
-
-            @Test
-            @DisplayName("purity, retouch, item를 null로 전송")
-            void modifyReviewSuccess2() {
-                // given
-                Long modifyReviewId = 1L;
-                Member user = Member.builder().id(1L).build();
-                RequestReviewDto modifyReviewDto = RequestReviewDto.builder().starRating(3).content("수정 후 리뷰 내용").build();
-
-                // when
-                when(reviewRepository.findById(modifyReviewId)).thenReturn(Optional.of(review));
-
-                ResponseReviewDto responseReviewDto = reviewService.modify(user, modifyReviewId, modifyReviewDto);
-
-                // then
-                Assertions.assertEquals(responseReviewDto.getReviewInfo().getId(), modifyReviewId);
-                Assertions.assertEquals(responseReviewDto.getReviewInfo().getStarRating(), modifyReviewDto.getStarRating());
-                Assertions.assertEquals(responseReviewDto.getReviewInfo().getContent(), modifyReviewDto.getContent());
-                Assertions.assertEquals(responseReviewDto.getReviewInfo().getPurity(), PurityScore.UNSELECTED);
-                Assertions.assertEquals(responseReviewDto.getReviewInfo().getRetouch(), RetouchScore.UNSELECTED);
-                Assertions.assertEquals(responseReviewDto.getReviewInfo().getItem(), ItemScore.UNSELECTED);
-
-                Assertions.assertEquals(responseReviewDto.getMemberInfo().getId(), writer.getId());
-                Assertions.assertEquals(responseReviewDto.getMemberInfo().getNickname(), writer.getNickname());
-
-                Assertions.assertEquals(responseReviewDto.getShopInfo().getId(), shop.getId());
-                Assertions.assertEquals(responseReviewDto.getShopInfo().getPlaceName(), shop.getPlaceName());
-            }
-        }
-
-        @Nested
-        @DisplayName("실패")
-        class FailCase {
-            @Test
-            @DisplayName("해당 id 가진 리뷰 존재하지 않음")
-            void modifyReviewFail1() {
-                // given
-                Long modifyReviewId = 2L;
-                Member user = Member.builder().id(1L).build();
-                RequestReviewDto modifyReviewDto = RequestReviewDto.builder().starRating(3).content("수정 후 리뷰 내용").purity("GOOD").retouch("GOOD").item("GOOD").build();
-                BusinessException exception = new BusinessException(ErrorCode.REVIEW_NOT_FOUND);
-
-                // when
-                when(reviewRepository.findById(modifyReviewId)).thenThrow(exception);
-
-                // then
-                BusinessException resultException = Assertions.assertThrows(exception.getClass(), () -> reviewService.modify(user, modifyReviewId, modifyReviewDto));
-                Assertions.assertEquals(resultException.getErrorCode(), exception.getErrorCode());
-                Assertions.assertEquals(resultException.getMessage(), exception.getMessage());
-            }
-
-            @Test
-            @DisplayName("사용자와 리뷰 작성자 불일치")
-            void modifyReviewFail2() {
-                // given
-                Long modifyReviewId = 1L;
-                Member user = Member.builder().id(2L).build();
-                RequestReviewDto modifyReviewDto = RequestReviewDto.builder().starRating(3).content("수정 후 리뷰 내용").purity("GOOD").retouch("GOOD").item("GOOD").build();
-                BusinessException exception = new BusinessException(ErrorCode.WRITER_DOES_NOT_MATCH);
-
-                // when
-                when(reviewRepository.findById(modifyReviewId)).thenReturn(Optional.of(review));
-
-                // then
-                BusinessException resultException = Assertions.assertThrows(exception.getClass(), () -> reviewService.modify(user, modifyReviewId, modifyReviewDto));
-                Assertions.assertEquals(resultException.getErrorCode(), exception.getErrorCode());
-                Assertions.assertEquals(resultException.getMessage(), exception.getMessage());
-            }
-        }
-    }
-
-    @Nested
-    @DisplayName("특정 리뷰 삭제")
-    class DeleteReview {
-        private Member writer;
-        private Brand brand;
-        private Shop shop;
-        private Review review;
-
-        @BeforeEach
-        void setUp() {
-            writer = Member.builder().id(1L).kakaoId(1000L).nickname("user1").build();
-            brand = Brand.builder().id(1L).brandName("인생네컷").filePath("https://d18tllc1sxg8cp.cloudfront.net/brand_image/brand_1.jpg").build();
-            shop = Shop.builder().id(1L).brand(brand).placeName("인생네컷망리단길점").address("서울 마포구 포은로 109-1").favoriteCnt(0).reviewCnt(0).starRatingAvg(0.0).build();
-            review = Review.builder().id(1L).createDate(LocalDateTime.now()).modifyDate(LocalDateTime.now()).writer(writer).shop(shop).starRating(5).content("리뷰 내용").purity(PurityScore.UNSELECTED).retouch(RetouchScore.UNSELECTED).item(ItemScore.UNSELECTED).build();
-        }
-
-        @Nested
-        @DisplayName("성공")
-        class SuccessCase {
-
-        }
-
-        @Nested
-        @DisplayName("실패")
-        class FailCase {
-            @Test
-            @DisplayName("해당 id 가진 리뷰 존재하지 않음")
-            void modifyReviewFail1() {
-                // given
-                Long deleteReviewId = 2L;
-                Member user = Member.builder().id(1L).build();
-                BusinessException exception = new BusinessException(ErrorCode.REVIEW_NOT_FOUND);
-
-                // when
-                when(reviewRepository.findById(deleteReviewId)).thenThrow(exception);
-
-                // then
-                BusinessException resultException = Assertions.assertThrows(exception.getClass(), () -> reviewService.delete(user, deleteReviewId));
-                Assertions.assertEquals(resultException.getErrorCode(), exception.getErrorCode());
-                Assertions.assertEquals(resultException.getMessage(), exception.getMessage());
-            }
-
-            @Test
-            @DisplayName("사용자와 리뷰 작성자 불일치")
-            void modifyReviewFail2() {
-                // given
-                Long modifyReviewId = 1L;
-                Member user = Member.builder().id(2L).build();
-                BusinessException exception = new BusinessException(ErrorCode.WRITER_DOES_NOT_MATCH);
-
-                // when
-                when(reviewRepository.findById(modifyReviewId)).thenReturn(Optional.of(review));
-
-                // then
-                BusinessException resultException = Assertions.assertThrows(exception.getClass(), () -> reviewService.delete(user, modifyReviewId));
-                Assertions.assertEquals(resultException.getErrorCode(), exception.getErrorCode());
+                BusinessException resultException = Assertions.assertThrows(exception.getClass(), () -> reviewReadService.getReviewById(retrieveReviewId));
                 Assertions.assertEquals(resultException.getMessage(), exception.getMessage());
             }
         }
@@ -317,7 +141,7 @@ public class ReviewServiceTest {
                 // when
                 when(reviewRepository.findAllByWriterIdOrderByCreateDateDesc(memberId)).thenReturn(reviews);
 
-                List<ResponseMemberReviewDto> memberReviews = reviewService.getAllMemberReviews(memberId);
+                List<ResponseMemberReviewDto> memberReviews = reviewReadService.getAllMemberReviews(memberId);
 
                 // then
                 Assertions.assertEquals(memberReviews.size(), 2);
@@ -344,7 +168,7 @@ public class ReviewServiceTest {
                 // when
                 when(reviewRepository.findAllByWriterIdOrderByCreateDateDesc(memberId)).thenReturn(reviews);
 
-                List<ResponseMemberReviewDto> memberReviews = reviewService.getAllMemberReviews(memberId);
+                List<ResponseMemberReviewDto> memberReviews = reviewReadService.getAllMemberReviews(memberId);
 
                 // then
                 Assertions.assertEquals(memberReviews.size(), 1);
@@ -366,7 +190,7 @@ public class ReviewServiceTest {
                 // when
                 when(reviewRepository.findAllByWriterIdOrderByCreateDateDesc(memberId)).thenReturn(reviews);
 
-                List<ResponseMemberReviewDto> memberReviews = reviewService.getAllMemberReviews(memberId);
+                List<ResponseMemberReviewDto> memberReviews = reviewReadService.getAllMemberReviews(memberId);
 
                 // then
                 Assertions.assertEquals(memberReviews.size(), 0);
@@ -424,7 +248,7 @@ public class ReviewServiceTest {
                 when(shopService.findById(shopId)).thenReturn(shop1);
                 when(reviewRepository.findAllByShopIdOrderByCreateDateDesc(shopId)).thenReturn(reviews);
 
-                List<ResponseShopReviewDto> shopReviews = reviewService.getAllShopReviews(shopId);
+                List<ResponseShopReviewDto> shopReviews = reviewReadService.getAllShopReviews(shopId);
 
                 // then
                 Assertions.assertEquals(shopReviews.size(), reviews.size());
@@ -452,7 +276,7 @@ public class ReviewServiceTest {
                 when(shopService.findById(shopId)).thenReturn(shop2);
                 when(reviewRepository.findAllByShopIdOrderByCreateDateDesc(shopId)).thenReturn(reviews);
 
-                List<ResponseShopReviewDto> shopReviews = reviewService.getAllShopReviews(shopId);
+                List<ResponseShopReviewDto> shopReviews = reviewReadService.getAllShopReviews(shopId);
 
                 // then
                 Assertions.assertEquals(shopReviews.size(), reviews.size());
@@ -474,7 +298,7 @@ public class ReviewServiceTest {
                 when(shopService.findById(shopId)).thenReturn(shop3);
                 when(reviewRepository.findAllByShopIdOrderByCreateDateDesc(shopId)).thenReturn(reviews);
 
-                List<ResponseShopReviewDto> shopReviews = reviewService.getAllShopReviews(shopId);
+                List<ResponseShopReviewDto> shopReviews = reviewReadService.getAllShopReviews(shopId);
 
                 // then
                 Assertions.assertEquals(shopReviews.size(), reviews.size());
@@ -495,116 +319,7 @@ public class ReviewServiceTest {
                 when(shopService.findById(shopId)).thenThrow(exception);
 
                 // then
-                BusinessException resultException = Assertions.assertThrows(exception.getClass(), () -> reviewService.getAllShopReviews(shopId));
-                Assertions.assertEquals(resultException.getErrorCode(), exception.getErrorCode());
-                Assertions.assertEquals(resultException.getMessage(), exception.getMessage());
-            }
-        }
-    }
-
-    @Nested
-    @DisplayName("상점 리뷰 작성")
-    class WriteReviewShop {
-        private Member writer;
-        private Brand brand;
-        private Shop shop;
-
-        @BeforeEach
-        void setUp() {
-            writer = Member.builder().id(1L).kakaoId(1000L).nickname("user1").build();
-            brand = Brand.builder().id(1L).brandName("인생네컷").filePath("https://d18tllc1sxg8cp.cloudfront.net/brand_image/brand_1.jpg").build();
-            shop = Shop.builder().id(1L).brand(brand).placeName("인생네컷망리단길점").address("서울 마포구 포은로 109-1").favoriteCnt(0).reviewCnt(0).starRatingAvg(0.0).build();
-        }
-
-        @Nested
-        @DisplayName("성공")
-        class SuccessCase {
-            @Test
-            @DisplayName("shopId 가진 지점에 review 추가")
-            void writeReviewShopSuccess1() {
-                // given
-                Long shopId = 1L;
-                RequestReviewDto requestReviewDto = RequestReviewDto.builder().starRating(3).content("새로 지점에 추가하는 리뷰 내용").purity("GOOD").retouch("GOOD").item("GOOD").build();
-                Review review = Review.builder()
-                        .id(1L)
-                        .createDate(LocalDateTime.now())
-                        .modifyDate(LocalDateTime.now())
-                        .writer(writer)
-                        .shop(shop)
-                        .starRating(requestReviewDto.getStarRating())
-                        .content(requestReviewDto.getContent())
-                        .purity(PurityScore.valueOf(requestReviewDto.getPurity()))
-                        .retouch(RetouchScore.valueOf(requestReviewDto.getRetouch()))
-                        .item(ItemScore.valueOf(requestReviewDto.getItem()))
-                        .build();
-
-                // when
-                when(shopService.findById(shopId)).thenReturn(shop);
-                when(reviewRepository.save(any(Review.class))).thenReturn(review);
-
-                ResponseReviewDto responseReviewDto = reviewService.write(writer, shopId, requestReviewDto);
-
-                // then
-                Assertions.assertEquals(responseReviewDto.getReviewInfo().getId(), review.getId());
-                Assertions.assertEquals(responseReviewDto.getReviewInfo().getStarRating(), review.getStarRating());
-                Assertions.assertEquals(responseReviewDto.getReviewInfo().getContent(), review.getContent());
-
-            }
-
-            @Test
-            @DisplayName("shopId 가진 지점에 purity, retouch, item null인 review 추가")
-            void retrieveShopReviewsSuccess2() {
-                // given
-                Long shopId = 1L;
-                RequestReviewDto requestReviewDto = RequestReviewDto.builder().starRating(3).content("새로 지점에 추가하는 리뷰 내용").build();
-                Review review = Review.builder()
-                        .id(1L)
-                        .createDate(LocalDateTime.now())
-                        .modifyDate(LocalDateTime.now())
-                        .writer(writer)
-                        .shop(shop)
-                        .starRating(requestReviewDto.getStarRating())
-                        .content(requestReviewDto.getContent())
-                        .purity(PurityScore.UNSELECTED)
-                        .retouch(RetouchScore.UNSELECTED)
-                        .item(ItemScore.UNSELECTED)
-                        .build();
-
-                // when
-                when(shopService.findById(shopId)).thenReturn(shop);
-                when(reviewRepository.save(any(Review.class))).thenReturn(review);
-
-                ResponseReviewDto responseReviewDto = reviewService.write(writer, shopId, requestReviewDto);
-
-                // then
-                Assertions.assertEquals(responseReviewDto.getReviewInfo().getId(), review.getId());
-                Assertions.assertEquals(responseReviewDto.getReviewInfo().getStarRating(), review.getStarRating());
-                Assertions.assertEquals(responseReviewDto.getReviewInfo().getContent(), review.getContent());
-                Assertions.assertEquals(responseReviewDto.getReviewInfo().getPurity(), review.getPurity());
-                Assertions.assertEquals(responseReviewDto.getReviewInfo().getRetouch(), review.getRetouch());
-                Assertions.assertEquals(responseReviewDto.getReviewInfo().getItem(), review.getItem());
-
-                Assertions.assertEquals(responseReviewDto.getShopInfo().getId(), shop.getId());
-                Assertions.assertEquals(responseReviewDto.getShopInfo().getPlaceName(), shop.getPlaceName());
-            }
-        }
-
-        @Nested
-        @DisplayName("실패")
-        class FailCase {
-            @Test
-            @DisplayName("ShopId 존재하지 않는 지점")
-            void retrieveShopReviewsFail1() {
-                // given
-                Long shopId = 2L;
-                RequestReviewDto requestReviewDto = RequestReviewDto.builder().starRating(3).content("새로 지점에 추가하는 리뷰 내용").purity("GOOD").retouch("GOOD").item("GOOD").build();
-                BusinessException exception = new BusinessException(ErrorCode.SHOP_NOT_FOUND);
-
-                // when
-                when(shopService.findById(shopId)).thenThrow(exception);
-
-                // then
-                BusinessException resultException = Assertions.assertThrows(exception.getClass(), () -> reviewService.write(writer, shopId, requestReviewDto));
+                BusinessException resultException = Assertions.assertThrows(exception.getClass(), () -> reviewReadService.getAllShopReviews(shopId));
                 Assertions.assertEquals(resultException.getErrorCode(), exception.getErrorCode());
                 Assertions.assertEquals(resultException.getMessage(), exception.getMessage());
             }
@@ -641,7 +356,7 @@ public class ReviewServiceTest {
                 when(reviewRepository.countByShop(shop)).thenReturn(reviewCount);
                 when(reviewRepository.getAverageStarRating(shopId)).thenReturn(starRatingAvg);
 
-                ShopReviewInfoDto shopReviewInfo = reviewService.getShopReviewInfo(shopId);
+                ShopReviewInfoDto shopReviewInfo = reviewReadService.getShopReviewInfo(shopId);
 
                 // then
                 Assertions.assertEquals(shopReviewInfo.getShopId(), shopId);
@@ -661,7 +376,7 @@ public class ReviewServiceTest {
                 when(shopService.findById(shopId)).thenReturn(shop);
                 when(reviewRepository.countByShop(shop)).thenReturn(reviewCount);
 
-                ShopReviewInfoDto shopReviewInfo = reviewService.getShopReviewInfo(shopId);
+                ShopReviewInfoDto shopReviewInfo = reviewReadService.getShopReviewInfo(shopId);
 
                 // then
                 Assertions.assertEquals(shopReviewInfo.getShopId(), shopId);
@@ -684,7 +399,7 @@ public class ReviewServiceTest {
                 when(shopService.findById(shopId)).thenThrow(exception);
 
                 // then
-                BusinessException resultException = Assertions.assertThrows(exception.getClass(), () -> reviewService.getShopReviewInfo(shopId));
+                BusinessException resultException = Assertions.assertThrows(exception.getClass(), () -> reviewReadService.getShopReviewInfo(shopId));
                 Assertions.assertEquals(resultException.getErrorCode(), exception.getErrorCode());
                 Assertions.assertEquals(resultException.getMessage(), exception.getMessage());
             }
@@ -727,7 +442,7 @@ public class ReviewServiceTest {
                 // when
                 when(reviewRepository.countByWriter(user)).thenReturn(userReviewCnt);
 
-                Long result = reviewService.getReviewCntByWriter(user);
+                Long result = reviewReadService.getReviewCntByWriter(user);
 
                 // then
                 Assertions.assertEquals(userReviewCnt, result);
@@ -743,7 +458,7 @@ public class ReviewServiceTest {
                 // when
                 when(reviewRepository.countByWriter(user)).thenReturn(userReviewCnt);
 
-                Long resultCnt = reviewService.getReviewCntByWriter(user);
+                Long resultCnt = reviewReadService.getReviewCntByWriter(user);
 
                 // then
                 Assertions.assertEquals(userReviewCnt, resultCnt);
@@ -805,7 +520,7 @@ public class ReviewServiceTest {
                 // when
                 when(reviewRepository.findTop3ByShopIdOrderByCreateDateDesc(shopId)).thenReturn(topShopReviews);
 
-                List<ResponseShopReviewDto> resultShopReviewDtoList = reviewService.getTop3ShopReviews(shopId);
+                List<ResponseShopReviewDto> resultShopReviewDtoList = reviewReadService.getTop3ShopReviews(shopId);
 
                 // then
                 Assertions.assertEquals(resultShopReviewDtoList.size(), 3);
@@ -830,7 +545,7 @@ public class ReviewServiceTest {
                 // when
                 when(reviewRepository.findTop3ByShopIdOrderByCreateDateDesc(shopId)).thenReturn(topShopReviews);
 
-                List<ResponseShopReviewDto> resultShopReviewDtoList = reviewService.getTop3ShopReviews(shopId);
+                List<ResponseShopReviewDto> resultShopReviewDtoList = reviewReadService.getTop3ShopReviews(shopId);
 
                 // then
                 Assertions.assertEquals(resultShopReviewDtoList.size(), reviewCnt);

--- a/src/test/java/com/idea5/four_cut_photos_map/domain/review/unit/service/ReviewWriteServiceTest.java
+++ b/src/test/java/com/idea5/four_cut_photos_map/domain/review/unit/service/ReviewWriteServiceTest.java
@@ -1,0 +1,319 @@
+package com.idea5.four_cut_photos_map.domain.review.unit.service;
+
+import com.idea5.four_cut_photos_map.domain.brand.entity.Brand;
+import com.idea5.four_cut_photos_map.domain.member.entity.Member;
+import com.idea5.four_cut_photos_map.domain.review.dto.request.RequestReviewDto;
+import com.idea5.four_cut_photos_map.domain.review.dto.response.ResponseReviewDto;
+import com.idea5.four_cut_photos_map.domain.review.entity.Review;
+import com.idea5.four_cut_photos_map.domain.review.entity.score.ItemScore;
+import com.idea5.four_cut_photos_map.domain.review.entity.score.PurityScore;
+import com.idea5.four_cut_photos_map.domain.review.entity.score.RetouchScore;
+import com.idea5.four_cut_photos_map.domain.review.repository.ReviewRepository;
+import com.idea5.four_cut_photos_map.domain.review.service.ReviewWriteService;
+import com.idea5.four_cut_photos_map.domain.shop.entity.Shop;
+import com.idea5.four_cut_photos_map.domain.shop.service.ShopService;
+import com.idea5.four_cut_photos_map.global.error.ErrorCode;
+import com.idea5.four_cut_photos_map.global.error.exception.BusinessException;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ReviewWriteServiceTest {
+    @InjectMocks
+    private ReviewWriteService reviewWriteService;
+    @Mock
+    private ReviewRepository reviewRepository;
+
+    @Mock
+    private ShopService shopService;
+
+    @Nested
+    @DisplayName("상점 리뷰 작성")
+    class WriteReviewShop {
+        private Member writer;
+        private Brand brand;
+        private Shop shop;
+
+        @BeforeEach
+        void setUp() {
+            writer = Member.builder().id(1L).kakaoId(1000L).nickname("user1").build();
+            brand = Brand.builder().id(1L).brandName("인생네컷").filePath("https://d18tllc1sxg8cp.cloudfront.net/brand_image/brand_1.jpg").build();
+            shop = Shop.builder().id(1L).brand(brand).placeName("인생네컷망리단길점").address("서울 마포구 포은로 109-1").favoriteCnt(0).reviewCnt(0).starRatingAvg(0.0).build();
+        }
+
+        @Nested
+        @DisplayName("성공")
+        class SuccessCase {
+            @Test
+            @DisplayName("shopId 가진 지점에 review 추가")
+            void writeReviewShopSuccess1() {
+                // given
+                Long shopId = 1L;
+                RequestReviewDto requestReviewDto = RequestReviewDto.builder().starRating(3).content("새로 지점에 추가하는 리뷰 내용").purity("GOOD").retouch("GOOD").item("GOOD").build();
+                Review review = Review.builder()
+                        .id(1L)
+                        .createDate(LocalDateTime.now())
+                        .modifyDate(LocalDateTime.now())
+                        .writer(writer)
+                        .shop(shop)
+                        .starRating(requestReviewDto.getStarRating())
+                        .content(requestReviewDto.getContent())
+                        .purity(PurityScore.valueOf(requestReviewDto.getPurity()))
+                        .retouch(RetouchScore.valueOf(requestReviewDto.getRetouch()))
+                        .item(ItemScore.valueOf(requestReviewDto.getItem()))
+                        .build();
+
+                // when
+                when(shopService.findById(shopId)).thenReturn(shop);
+                when(reviewRepository.save(any(Review.class))).thenReturn(review);
+
+                ResponseReviewDto responseReviewDto = reviewWriteService.write(writer, shopId, requestReviewDto);
+
+                // then
+                Assertions.assertEquals(responseReviewDto.getReviewInfo().getId(), review.getId());
+                Assertions.assertEquals(responseReviewDto.getReviewInfo().getStarRating(), review.getStarRating());
+                Assertions.assertEquals(responseReviewDto.getReviewInfo().getContent(), review.getContent());
+
+            }
+
+            @Test
+            @DisplayName("shopId 가진 지점에 purity, retouch, item null인 review 추가")
+            void retrieveShopReviewsSuccess2() {
+                // given
+                Long shopId = 1L;
+                RequestReviewDto requestReviewDto = RequestReviewDto.builder().starRating(3).content("새로 지점에 추가하는 리뷰 내용").build();
+                Review review = Review.builder()
+                        .id(1L)
+                        .createDate(LocalDateTime.now())
+                        .modifyDate(LocalDateTime.now())
+                        .writer(writer)
+                        .shop(shop)
+                        .starRating(requestReviewDto.getStarRating())
+                        .content(requestReviewDto.getContent())
+                        .purity(PurityScore.UNSELECTED)
+                        .retouch(RetouchScore.UNSELECTED)
+                        .item(ItemScore.UNSELECTED)
+                        .build();
+
+                // when
+                when(shopService.findById(shopId)).thenReturn(shop);
+                when(reviewRepository.save(any(Review.class))).thenReturn(review);
+
+                ResponseReviewDto responseReviewDto = reviewWriteService.write(writer, shopId, requestReviewDto);
+
+                // then
+                Assertions.assertEquals(responseReviewDto.getReviewInfo().getId(), review.getId());
+                Assertions.assertEquals(responseReviewDto.getReviewInfo().getStarRating(), review.getStarRating());
+                Assertions.assertEquals(responseReviewDto.getReviewInfo().getContent(), review.getContent());
+                Assertions.assertEquals(responseReviewDto.getReviewInfo().getPurity(), review.getPurity());
+                Assertions.assertEquals(responseReviewDto.getReviewInfo().getRetouch(), review.getRetouch());
+                Assertions.assertEquals(responseReviewDto.getReviewInfo().getItem(), review.getItem());
+
+                Assertions.assertEquals(responseReviewDto.getShopInfo().getId(), shop.getId());
+                Assertions.assertEquals(responseReviewDto.getShopInfo().getPlaceName(), shop.getPlaceName());
+            }
+        }
+
+        @Nested
+        @DisplayName("실패")
+        class FailCase {
+            @Test
+            @DisplayName("ShopId 존재하지 않는 지점")
+            void retrieveShopReviewsFail1() {
+                // given
+                Long shopId = 2L;
+                RequestReviewDto requestReviewDto = RequestReviewDto.builder().starRating(3).content("새로 지점에 추가하는 리뷰 내용").purity("GOOD").retouch("GOOD").item("GOOD").build();
+                BusinessException exception = new BusinessException(ErrorCode.SHOP_NOT_FOUND);
+
+                // when
+                when(shopService.findById(shopId)).thenThrow(exception);
+
+                // then
+                BusinessException resultException = Assertions.assertThrows(exception.getClass(), () -> reviewWriteService.write(writer, shopId, requestReviewDto));
+                Assertions.assertEquals(resultException.getErrorCode(), exception.getErrorCode());
+                Assertions.assertEquals(resultException.getMessage(), exception.getMessage());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("특정 리뷰 수정")
+    class ModifyReview {
+        private Member writer;
+        private Brand brand;
+        private Shop shop;
+        private Review review;
+
+        @BeforeEach
+        void setUp() {
+            writer = Member.builder().id(1L).kakaoId(1000L).nickname("user1").build();
+            brand = Brand.builder().id(1L).brandName("인생네컷").filePath("https://d18tllc1sxg8cp.cloudfront.net/brand_image/brand_1.jpg").build();
+            shop = Shop.builder().id(1L).brand(brand).placeName("인생네컷망리단길점").address("서울 마포구 포은로 109-1").favoriteCnt(0).reviewCnt(0).starRatingAvg(0.0).build();
+            review = Review.builder().id(1L).createDate(LocalDateTime.now()).modifyDate(LocalDateTime.now()).writer(writer).shop(shop).starRating(5).content("리뷰 내용").purity(PurityScore.BAD).retouch(RetouchScore.BAD).item(ItemScore.BAD).build();
+        }
+
+        @Nested
+        @DisplayName("성공")
+        class SuccessCase {
+            @Test
+            @DisplayName("해당 id 가진 리뷰 수정")
+            void modifyReviewSuccess1() {
+                // given
+                Long modifyReviewId = 1L;
+                Member user = Member.builder().id(1L).build();
+                RequestReviewDto modifyReviewDto = RequestReviewDto.builder().starRating(3).content("수정 후 리뷰 내용").purity("GOOD").retouch("GOOD").item("GOOD").build();
+
+                // when
+                when(reviewRepository.findById(modifyReviewId)).thenReturn(Optional.of(review));
+
+                ResponseReviewDto responseReviewDto = reviewWriteService.modify(user, modifyReviewId, modifyReviewDto);
+
+                // then
+                Assertions.assertEquals(responseReviewDto.getReviewInfo().getStarRating(), modifyReviewDto.getStarRating());
+                Assertions.assertEquals(responseReviewDto.getReviewInfo().getContent(), modifyReviewDto.getContent());
+                Assertions.assertEquals(responseReviewDto.getReviewInfo().getPurity(), PurityScore.valueOf(modifyReviewDto.getPurity()));
+                Assertions.assertEquals(String.valueOf(responseReviewDto.getReviewInfo().getRetouch()), modifyReviewDto.getRetouch());
+                Assertions.assertEquals(String.valueOf(responseReviewDto.getReviewInfo().getItem()), modifyReviewDto.getItem());
+            }
+
+            @Test
+            @DisplayName("purity, retouch, item를 null로 전송")
+            void modifyReviewSuccess2() {
+                // given
+                Long modifyReviewId = 1L;
+                Member user = Member.builder().id(1L).build();
+                RequestReviewDto modifyReviewDto = RequestReviewDto.builder().starRating(3).content("수정 후 리뷰 내용").build();
+
+                // when
+                when(reviewRepository.findById(modifyReviewId)).thenReturn(Optional.of(review));
+
+                ResponseReviewDto responseReviewDto = reviewWriteService.modify(user, modifyReviewId, modifyReviewDto);
+
+                // then
+                Assertions.assertEquals(responseReviewDto.getReviewInfo().getId(), modifyReviewId);
+                Assertions.assertEquals(responseReviewDto.getReviewInfo().getStarRating(), modifyReviewDto.getStarRating());
+                Assertions.assertEquals(responseReviewDto.getReviewInfo().getContent(), modifyReviewDto.getContent());
+                Assertions.assertEquals(responseReviewDto.getReviewInfo().getPurity(), PurityScore.UNSELECTED);
+                Assertions.assertEquals(responseReviewDto.getReviewInfo().getRetouch(), RetouchScore.UNSELECTED);
+                Assertions.assertEquals(responseReviewDto.getReviewInfo().getItem(), ItemScore.UNSELECTED);
+
+                Assertions.assertEquals(responseReviewDto.getMemberInfo().getId(), writer.getId());
+                Assertions.assertEquals(responseReviewDto.getMemberInfo().getNickname(), writer.getNickname());
+
+                Assertions.assertEquals(responseReviewDto.getShopInfo().getId(), shop.getId());
+                Assertions.assertEquals(responseReviewDto.getShopInfo().getPlaceName(), shop.getPlaceName());
+            }
+        }
+
+        @Nested
+        @DisplayName("실패")
+        class FailCase {
+            @Test
+            @DisplayName("해당 id 가진 리뷰 존재하지 않음")
+            void modifyReviewFail1() {
+                // given
+                Long modifyReviewId = 2L;
+                Member user = Member.builder().id(1L).build();
+                RequestReviewDto modifyReviewDto = RequestReviewDto.builder().starRating(3).content("수정 후 리뷰 내용").purity("GOOD").retouch("GOOD").item("GOOD").build();
+                BusinessException exception = new BusinessException(ErrorCode.REVIEW_NOT_FOUND);
+
+                // when
+                when(reviewRepository.findById(modifyReviewId)).thenThrow(exception);
+
+                // then
+                BusinessException resultException = Assertions.assertThrows(exception.getClass(), () -> reviewWriteService.modify(user, modifyReviewId, modifyReviewDto));
+                Assertions.assertEquals(resultException.getErrorCode(), exception.getErrorCode());
+                Assertions.assertEquals(resultException.getMessage(), exception.getMessage());
+            }
+
+            @Test
+            @DisplayName("사용자와 리뷰 작성자 불일치")
+            void modifyReviewFail2() {
+                // given
+                Long modifyReviewId = 1L;
+                Member user = Member.builder().id(2L).build();
+                RequestReviewDto modifyReviewDto = RequestReviewDto.builder().starRating(3).content("수정 후 리뷰 내용").purity("GOOD").retouch("GOOD").item("GOOD").build();
+                BusinessException exception = new BusinessException(ErrorCode.WRITER_DOES_NOT_MATCH);
+
+                // when
+                when(reviewRepository.findById(modifyReviewId)).thenReturn(Optional.of(review));
+
+                // then
+                BusinessException resultException = Assertions.assertThrows(exception.getClass(), () -> reviewWriteService.modify(user, modifyReviewId, modifyReviewDto));
+                Assertions.assertEquals(resultException.getErrorCode(), exception.getErrorCode());
+                Assertions.assertEquals(resultException.getMessage(), exception.getMessage());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("특정 리뷰 삭제")
+    class DeleteReview {
+        private Member writer;
+        private Brand brand;
+        private Shop shop;
+        private Review review;
+
+        @BeforeEach
+        void setUp() {
+            writer = Member.builder().id(1L).kakaoId(1000L).nickname("user1").build();
+            brand = Brand.builder().id(1L).brandName("인생네컷").filePath("https://d18tllc1sxg8cp.cloudfront.net/brand_image/brand_1.jpg").build();
+            shop = Shop.builder().id(1L).brand(brand).placeName("인생네컷망리단길점").address("서울 마포구 포은로 109-1").favoriteCnt(0).reviewCnt(0).starRatingAvg(0.0).build();
+            review = Review.builder().id(1L).createDate(LocalDateTime.now()).modifyDate(LocalDateTime.now()).writer(writer).shop(shop).starRating(5).content("리뷰 내용").purity(PurityScore.UNSELECTED).retouch(RetouchScore.UNSELECTED).item(ItemScore.UNSELECTED).build();
+        }
+
+        @Nested
+        @DisplayName("성공")
+        class SuccessCase {
+
+        }
+
+        @Nested
+        @DisplayName("실패")
+        class FailCase {
+            @Test
+            @DisplayName("해당 id 가진 리뷰 존재하지 않음")
+            void modifyReviewFail1() {
+                // given
+                Long deleteReviewId = 2L;
+                Member user = Member.builder().id(1L).build();
+                BusinessException exception = new BusinessException(ErrorCode.REVIEW_NOT_FOUND);
+
+                // when
+                when(reviewRepository.findById(deleteReviewId)).thenThrow(exception);
+
+                // then
+                BusinessException resultException = Assertions.assertThrows(exception.getClass(), () -> reviewWriteService.delete(user, deleteReviewId));
+                Assertions.assertEquals(resultException.getErrorCode(), exception.getErrorCode());
+                Assertions.assertEquals(resultException.getMessage(), exception.getMessage());
+            }
+
+            @Test
+            @DisplayName("사용자와 리뷰 작성자 불일치")
+            void modifyReviewFail2() {
+                // given
+                Long modifyReviewId = 1L;
+                Member user = Member.builder().id(2L).build();
+                BusinessException exception = new BusinessException(ErrorCode.WRITER_DOES_NOT_MATCH);
+
+                // when
+                when(reviewRepository.findById(modifyReviewId)).thenReturn(Optional.of(review));
+
+                // then
+                BusinessException resultException = Assertions.assertThrows(exception.getClass(), () -> reviewWriteService.delete(user, modifyReviewId));
+                Assertions.assertEquals(resultException.getErrorCode(), exception.getErrorCode());
+                Assertions.assertEquals(resultException.getMessage(), exception.getMessage());
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
## 작업 목적
> 1. 리뷰 서비스 확장성 및 코드 응집성을 위한 내부의 조회(읽기) 관련 로직과 쓰기(추가, 삭제, 수정) 로직 서비스 분리
> 2. Review Entity 일관된 정보 저장을 위한 setter 삭제